### PR TITLE
fix: send bytes instead of bytes of string

### DIFF
--- a/proto/uniswap/v1/uniswap.proto
+++ b/proto/uniswap/v1/uniswap.proto
@@ -140,8 +140,8 @@ message Events {
     uint64 created_at_block_number = 108;
 
     message Swap {
-      string sender = 1;
-      string recipient = 2;
+      bytes sender = 1;
+      bytes recipient = 2;
       string origin = 3;
       // Decimal
       string amount_0 = 4;
@@ -156,7 +156,7 @@ message Events {
     }
 
     message Burn {
-      string owner = 1;
+      bytes owner = 1;
       string origin = 2;
       // Integer
       string amount = 3;
@@ -171,8 +171,8 @@ message Events {
     }
 
     message Mint {
-      string owner = 1;
-      string sender = 2;
+      bytes owner = 1;
+      bytes sender = 2;
       string origin = 3;
       // Decimal
       string amount_0 = 4;
@@ -273,7 +273,7 @@ message Events {
 
   message TransferPosition {
     string token_id = 1;
-    string owner = 2;
+    bytes owner = 2;
     uint64 log_ordinal = 10;
   }
 }
@@ -288,7 +288,7 @@ message SnapshotPosition {
   // the token_id of the position
   string position = 2;
   uint64 block_number = 3;
-  string owner = 4;
+  bytes owner = 4;
   uint64 timestamp = 6;
   // Decimal
   string liquidity = 7;

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -58,8 +58,8 @@ pub fn extract_pool_events_and_positions(
             timestamp: timestamp_seconds,
             created_at_block_number: block_number,
             r#type: Some(SwapEvent(events::pool_event::Swap {
-                sender: Hex(&swap.sender).to_string(),
-                recipient: Hex(&swap.recipient).to_string(),
+                sender: swap.sender,
+                recipient: swap.recipient,
                 origin: origin.to_string(),
                 amount_0: amount0.into(),
                 amount_1: amount1.into(),
@@ -102,8 +102,8 @@ pub fn extract_pool_events_and_positions(
             timestamp: timestamp_seconds,
             created_at_block_number: block_number,
             r#type: Some(MintEvent(events::pool_event::Mint {
-                owner: Hex(&mint.owner).to_string(),
-                sender: Hex(&mint.sender).to_string(),
+                owner: mint.owner,
+                sender: mint.sender,
                 origin: origin.to_string(),
                 amount: mint.amount.to_string(),
                 amount_0: amount0.into(),
@@ -231,7 +231,7 @@ pub fn extract_pool_events_and_positions(
             timestamp: timestamp_seconds,
             created_at_block_number: block_number,
             r#type: Some(BurnEvent(events::pool_event::Burn {
-                owner: Hex(&burn.owner).to_string(),
+                owner: burn.owner,
                 origin: origin.to_string(),
                 amount: burn.amount.into(),
                 amount_0: amount0.into(),
@@ -524,7 +524,7 @@ fn extract_positions(
         } else if let Some(event) = abi::positionmanager::events::Transfer::match_and_decode(log) {
             transfer_positions.push(events::TransferPosition {
                 token_id: event.token_id.to_string(),
-                owner: Hex(&event.to).to_string(),
+                owner: event.to,
                 log_ordinal: log.ordinal,
             });
         }

--- a/src/pb/uniswap.types.v1.rs
+++ b/src/pb/uniswap.types.v1.rs
@@ -227,10 +227,10 @@ pub mod events {
         #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Swap {
-            #[prost(string, tag="1")]
-            pub sender: ::prost::alloc::string::String,
-            #[prost(string, tag="2")]
-            pub recipient: ::prost::alloc::string::String,
+            #[prost(bytes="vec", tag="1")]
+            pub sender: ::prost::alloc::vec::Vec<u8>,
+            #[prost(bytes="vec", tag="2")]
+            pub recipient: ::prost::alloc::vec::Vec<u8>,
             #[prost(string, tag="3")]
             pub origin: ::prost::alloc::string::String,
             /// Decimal
@@ -252,8 +252,8 @@ pub mod events {
         #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Burn {
-            #[prost(string, tag="1")]
-            pub owner: ::prost::alloc::string::String,
+            #[prost(bytes="vec", tag="1")]
+            pub owner: ::prost::alloc::vec::Vec<u8>,
             #[prost(string, tag="2")]
             pub origin: ::prost::alloc::string::String,
             /// Integer
@@ -275,10 +275,10 @@ pub mod events {
         #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Mint {
-            #[prost(string, tag="1")]
-            pub owner: ::prost::alloc::string::String,
-            #[prost(string, tag="2")]
-            pub sender: ::prost::alloc::string::String,
+            #[prost(bytes="vec", tag="1")]
+            pub owner: ::prost::alloc::vec::Vec<u8>,
+            #[prost(bytes="vec", tag="2")]
+            pub sender: ::prost::alloc::vec::Vec<u8>,
             #[prost(string, tag="3")]
             pub origin: ::prost::alloc::string::String,
             /// Decimal
@@ -479,8 +479,8 @@ pub mod events {
     pub struct TransferPosition {
         #[prost(string, tag="1")]
         pub token_id: ::prost::alloc::string::String,
-        #[prost(string, tag="2")]
-        pub owner: ::prost::alloc::string::String,
+        #[prost(bytes="vec", tag="2")]
+        pub owner: ::prost::alloc::vec::Vec<u8>,
         #[prost(uint64, tag="10")]
         pub log_ordinal: u64,
     }
@@ -501,8 +501,8 @@ pub struct SnapshotPosition {
     pub position: ::prost::alloc::string::String,
     #[prost(uint64, tag="3")]
     pub block_number: u64,
-    #[prost(string, tag="4")]
-    pub owner: ::prost::alloc::string::String,
+    #[prost(bytes="vec", tag="4")]
+    pub owner: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag="6")]
     pub timestamp: u64,
     /// Decimal


### PR DESCRIPTION
while debugging issue on some other subgraph found that we were storing the `base64` that was because it was converting `String -> bytes` but we want to store the bytes directly so we can use the `Bytes` type in subgraphs to show the Hex value nicely

context: https://guild-oss.slack.com/archives/C03B2US85J4/p1688395836580659?thread_ts=1688359311.715519&cid=C03B2US85J4